### PR TITLE
Add throttling rule

### DIFF
--- a/spec/my_rule_spec.rb
+++ b/spec/my_rule_spec.rb
@@ -2,15 +2,16 @@ RSpec.describe MyRule do
 
   describe 'during split' do
 
-    let(:rule) { described_class.new(['3:00pm-3:20pm', '4:20pm-4:40pm'], 30) }
+    let(:rule) { described_class.new(['3:00pm-3:20pm', '4:20pm-4:50pm'], 30) }
+    let(:events) { rule.events.to_a }
 
     it 'splits events by during intervals' do
-      expect(rule.events.length).to eq(2)
+      expect(events.length).to eq(2)
     end
 
     it 'starts each interval in "during" time' do
-      expect(rule.events.first).to be_within(1.second).of(today_at(hour: 15, minute: 00))
-      expect(rule.events.last).to be_within(1.second).of(today_at(hour: 16, minute: 20))
+      expect(events.first).to be_within(1.second).of(today_at(hour: 15, minute: 00))
+      expect(events.last).to be_within(1.second).of(today_at(hour: 16, minute: 20))
     end
 
     def today_at(hour: 0, minute: 0)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,7 +3,7 @@
 # The generated `.rspec` file contains `--require spec_helper` which will cause
 # this file to always be loaded, without a need to explicitly require it in any
 # files.
-require '../src/my_rule'
+require_relative '../src/my_rule'
 
 # Given that it is always loaded, you are encouraged to keep this file as
 # light-weight as possible. Requiring heavyweight dependencies from this file

--- a/src/my_rule.rb
+++ b/src/my_rule.rb
@@ -1,7 +1,7 @@
 require 'montrose'
+require_relative './patch'
 
 class MyRule
-
   def initialize(during, interval)
     @during   = during
     @interval = interval
@@ -13,14 +13,14 @@ class MyRule
   end
 
   def events
-    @rule.events.to_a
+    @rule.events
   end
 
   private
 
   def build
     Montrose.minutely(
-      interval: @interval,
+      throttle_for: @interval * 60, # minutes
       during:   @during,
       starts:   Date.today.at_beginning_of_day,
       until:    Date.tomorrow.at_beginning_of_day)

--- a/src/patch.rb
+++ b/src/patch.rb
@@ -1,0 +1,45 @@
+# new rule
+module Montrose
+  module Rule
+    class ThrottleFor
+      include Montrose::Rule
+
+      def self.apply_options(opts)
+        opts[:throttle_for]
+      end
+
+      def initialize(throttle_for)
+        @throttle_for = throttle_for
+        @last_tick = nil
+      end
+
+      def include?(time)
+        return true if @last_tick.nil?
+        time - @last_tick > @throttle_for
+      end
+
+      def advance!(time)
+        @last_tick = time
+        continue?(time)
+      end
+
+      def continue?(_time)
+        true
+      end
+    end
+  end
+end
+
+# add option accessors
+Montrose::Options.class_eval do
+  def_option :throttle_for
+end
+
+# inject our new rule into the engine
+Montrose::Stack.singleton_class.prepend(Module.new do
+  def build(opts = {})
+    super + [
+        Montrose::Rule::ThrottleFor,
+    ].map { |r| r.from_options(opts) }.compact
+  end
+end)


### PR DESCRIPTION
This adds a new rule, `ThrottleFor`. It accepts a duration (in seconds) and prevents new events until duration elapses.

### Example

``` ruby
    Montrose.minutely(
        throttle_for: 30 * 60, # every 30 minutes
        during: ['3:00pm-3:20pm', '4:20pm-4:50pm'],
        starts: Date.today.at_beginning_of_day,
        until: Date.tomorrow.at_beginning_of_day,
    )
```

This will create two events, at 15:00 and 16:20.